### PR TITLE
Added "note off" support for buttons

### DIFF
--- a/app/src/main/assets/template1.json
+++ b/app/src/main/assets/template1.json
@@ -10,7 +10,7 @@ contents: [
 	text: "button",
 	rect: [213, 68, 513, 368],
 	width: 300,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 1 $1"
 },
 {
 	type:"button",
@@ -22,7 +22,7 @@ contents: [
 	text: "button",
 	rect: [562, 68, 862, 368],
 	width: 300,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 2 $1"
 },
 {
 	type:"button",
@@ -34,7 +34,7 @@ contents: [
 	text: "button",
 	rect: [213, 407, 513, 707],
 	width: 300,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 3 $1"
 },
 {
 	type:"button",
@@ -46,6 +46,6 @@ contents: [
 	text: "button",
 	rect: [562, 407, 862, 707],
 	width: 300,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 4 $1"
 }
 ]}

--- a/app/src/main/assets/template2.json
+++ b/app/src/main/assets/template2.json
@@ -52,7 +52,7 @@ contents: [
 	text: "button",
 	rect: [348, 516, 448, 616],
 	width: 100,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 1 $1"
 },
 {
 	type:"button",
@@ -64,7 +64,7 @@ contents: [
 	text: "button",
 	rect: [986, 517, 1086, 617],
 	width: 100,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 2 $1"
 },
 {
 	type:"vslider",

--- a/app/src/main/assets/template3.json
+++ b/app/src/main/assets/template3.json
@@ -104,7 +104,7 @@ contents: [
 	text: "button",
 	rect: [781, 139, 881, 239],
 	width: 100,
-	oscButtonPressed: "button 1"
+	oscButtonPressed: "button 1 $1"
 },
 {
 	type:"hslider",


### PR DESCRIPTION
I've added "note off" support for the "button" control, by adding a $1 parameter to the OSC string
which will be set to 1 or 0, depending on whether the button was pressed or released.

If $1 is not present in the OSC string, only the "pressed" event will be sent.
